### PR TITLE
Update EX8_1_CLAS_ZBP_I_RAP_BOOKING.txt

### DIFF
--- a/exercises/ex8/sources/EX8_1_CLAS_ZBP_I_RAP_BOOKING.txt
+++ b/exercises/ex8/sources/EX8_1_CLAS_ZBP_I_RAP_BOOKING.txt
@@ -13,7 +13,8 @@ CLASS lhc_Booking IMPLEMENTATION.
 
   METHOD calculateBookingID.
     DATA max_bookingid TYPE /dmo/booking_id.
-    DATA update TYPE TABLE FOR UPDATE ZI_RAP_Travel_####\\Booking.
+    "Just change this to ZI_RAP_Booking_#### instead of ZI_RAP_Travel_####\\Booking
+    DATA update TYPE TABLE FOR UPDATE ZI_RAP_Booking_####.
 
     " Read all travels for the requested bookings.
     " If multiple bookings of the same travel are requested, the travel is returned only once.


### PR DESCRIPTION
Just change this to ZI_RAP_Booking_#### instead of ZI_RAP_Travel_####\\Booking

If trailing \\Booking is deleted, it becomes unclear why there's a syntax error - ZI_RAP_Travel_#### will by correct syntax in line 16, but will cause other syntax issues elsewhere in the code. Unless of course you meant to teach us to look carefully at the update structure used :)